### PR TITLE
Fix a tie-break score bug

### DIFF
--- a/lib/atp_scraper.rb
+++ b/lib/atp_scraper.rb
@@ -1,5 +1,6 @@
 require "atp_scraper/version"
 require "atp_scraper/get"
+require "atp_scraper/utility"
 require "atp_scraper/html"
 require "atp_scraper/activity"
 require "atp_scraper/ranking"

--- a/lib/atp_scraper/activities/record.rb
+++ b/lib/atp_scraper/activities/record.rb
@@ -20,27 +20,10 @@ module AtpScraper
           when 3 then
             result[:win_loss] = record_content
           when 4 then
-            result[:score] = convert_score(record_content)
+            result[:score] = AtpScraper::Utility.convert_score(record_content)
           end
         end
         result
-      end
-
-      private
-
-      # "62 765" -> "62 76(5)"
-      # "768 64 46 46 76-74" -> "76(8) 64 46 46 76-74"
-      def convert_score(score)
-        result = []
-        score.split("\s").each do |s|
-          # Str starts '76' or '67' (not '76-' or '67-')
-          if (a = s.slice!(/^(76|67)(?!-)/))
-            result.push("#{a}(#{s})")
-          else
-            result.push(s)
-          end
-        end
-        result.join("\s")
       end
     end
   end

--- a/lib/atp_scraper/utility.rb
+++ b/lib/atp_scraper/utility.rb
@@ -1,0 +1,20 @@
+module AtpScraper
+  # Utility class
+  class Utility
+    # "62 765" -> "62 76(5)"
+    # "768 64 46 46 76-74" -> "76(8) 64 46 46 76-74"
+    # "76 63" -> "76 64"
+    def self.convert_score(score)
+      result = []
+      score.split("\s").each do |s|
+        # Str starts '76' or '67' (not '76-' or '67-')
+        if (a = s.slice!(/^(76|67)(?!-|$)/))
+          result.push("#{a}(#{s})")
+        else
+          result.push(s)
+        end
+      end
+      result.join("\s")
+    end
+  end
+end

--- a/lib/atp_scraper/version.rb
+++ b/lib/atp_scraper/version.rb
@@ -1,3 +1,3 @@
 module AtpScraper
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end

--- a/test/atp_scraper/test_utility.rb
+++ b/test/atp_scraper/test_utility.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class TestActivity < Test::Unit::TestCase
+  test "Normal score case" do
+    expected = "76(3) 67(10) 64"
+    actual = AtpScraper::Utility.convert_score("763 6710 64")
+    assert_equal(actual, expected)
+  end
+
+  test "Final set score is 76 or 67" do
+    expected1 = "76(3) 67(4) 64 36 76-74"
+    actual1 = AtpScraper::Utility.convert_score("763 674 64 36 76-74")
+    assert_equal(actual1, expected1)
+
+    expected2 = "76(3) 67(4) 64 36 67-65"
+    actual2 = AtpScraper::Utility.convert_score("763 674 64 36 67-65")
+    assert_equal(actual2, expected2)
+  end
+
+  test "Without tie-break sub score" do
+    expected = "76 67 64"
+    actual = AtpScraper::Utility.convert_score("76 67 64")
+    assert_equal(actual, expected)
+  end
+end


### PR DESCRIPTION
Without tie-break sub score
before: 76 64 -> 76() 64
after:  76 64 -> 76 64
